### PR TITLE
Slack を chat.postMessage API に移行し Markdown ブロックサポートと Http クライアントのバグ修正を実施

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ composer.lock
 /build/
 phar-composer.phar
 rocket.phar
+rocket.json
 /phpunit.xml
 /.phpunit.result.cache
 /.phpcs-cache

--- a/src/Command/DeployCommand.php
+++ b/src/Command/DeployCommand.php
@@ -14,9 +14,9 @@ use Rocket\ProcessEvents;
 use Rocket\Slack;
 use Rocket\Slack\BlockKit\Block\Context as SlackContext;
 use Rocket\Slack\BlockKit\Block\Divider as SlackDivider;
-use Rocket\Slack\BlockKit\Block\Header as SlackHeader;
+use Rocket\Slack\BlockKit\Block\Markdown as SlackMarkdown;
 use Rocket\Slack\BlockKit\Block\Section as SlackSection;
-use Rocket\Slack\BlockKit\Element\Markdown as SlackMarkdown;
+use Rocket\Slack\BlockKit\Element\Mrkdwn as SlackMrkdwn;
 use Rocket\Slack\BlockKit\Element\PlainText as SlackPlainText;
 use Rocket\Slack\BlockKit\Message as SlackMessage;
 use Rocket\Version;
@@ -262,7 +262,7 @@ class DeployCommand implements CommandInterface
         $message = new SlackMessage('Deploy successful', $configure->read('slack.icon', ':sparkles:'));
         $message
             ->addBlock(
-                new SlackHeader(new SlackPlainText('Deploy successful'))
+                new SlackMarkdown('# Deploy successful')
             )
             ->addBlock(
                 (new SlackSection())->setText(
@@ -272,10 +272,10 @@ class DeployCommand implements CommandInterface
             ->addBlock(
                 (new SlackSection())
                     ->addField(
-                        new SlackMarkdown('**Hostname:**' . PHP_EOL . gethostname())
+                        new SlackMrkdwn('**Hostname:**' . PHP_EOL . gethostname())
                     )
                     ->addField(
-                        new SlackMarkdown('**URL:**' . PHP_EOL . $configure->read('url'))
+                        new SlackMrkdwn('**URL:**' . PHP_EOL . $configure->read('url'))
                     )
             );
 
@@ -285,20 +285,14 @@ class DeployCommand implements CommandInterface
                     new SlackDivider()
                 )
                 ->addBlock(
-                    (new SlackSection())
-                        ->addField(
-                            new SlackMarkdown('**Git pull**')
-                        )
+                    new SlackMarkdown('**Git pull**')
                 );
 
-            $chunks = $chunker($gitPullLog, SlackSection::TEXT_MAX_LENGTH - 6);
+            $chunks = $chunker($gitPullLog, SlackSection::MARKDOWN_MAX_LENGTH - 6);
             foreach ($chunks as $chunk) {
                 $message
                     ->addBlock(
-                        (new SlackSection())
-                            ->setText(
-                                new SlackMarkdown('```' . $chunk . '```')
-                            )
+                        new SlackMarkdown('```' . PHP_EOL . $chunk . PHP_EOL . '```')
                     );
             }
         }
@@ -309,20 +303,14 @@ class DeployCommand implements CommandInterface
                     new SlackDivider()
                 )
                 ->addBlock(
-                    (new SlackSection())
-                        ->addField(
-                            new SlackMarkdown('**Rsync**')
-                        )
+                    new SlackMarkdown('**Rsync**')
                 );
 
             $chunks = $chunker($syncLog, SlackSection::TEXT_MAX_LENGTH - 6);
             foreach ($chunks as $chunk) {
                 $message
                     ->addBlock(
-                        (new SlackSection())
-                            ->setText(
-                                new SlackMarkdown('```' . $chunk . '```')
-                            )
+                        new SlackMarkdown('```' . PHP_EOL . $chunk . PHP_EOL . '```')
                     );
             }
         }
@@ -334,18 +322,19 @@ class DeployCommand implements CommandInterface
             ->addBlock(
                 (new SlackContext())
                     ->addElement(
-                        new SlackMarkdown('Date: ' . date("Y/m/d H:i:s"))
+                        new SlackMrkdwn('Date: ' . date("Y/m/d H:i:s"))
                     )
                     ->addElement(
-                        new SlackMarkdown('Version: ' . Main::appName() . ' ' . Version::ROCKET_VERSION)
+                        new SlackMrkdwn('Version: ' . Main::appName() . ' ' . Version::ROCKET_VERSION)
                     )
                     ->addElement(
-                        new SlackMarkdown('Configuration: ' . $configure->getConfigPath())
+                        new SlackMrkdwn('Configuration: ' . $configure->getConfigPath())
                     )
             );
 
         $slack = new Slack(
-            $configure->read('slack.incomingWebhook'),
+            $configure->read('slack.chatPostMessageUrl'),
+            $configure->read('slack.appOauthToken'),
             $configure->read('slack.channel'),
             $configure->read('slack.username'),
             $this->http

--- a/src/Command/SlackNotificationCommand.php
+++ b/src/Command/SlackNotificationCommand.php
@@ -11,8 +11,9 @@ use Rocket\Options;
 use Rocket\Slack;
 use Rocket\Slack\BlockKit\Block\Context as SlackContext;
 use Rocket\Slack\BlockKit\Block\Divider as SlackDivider;
+use Rocket\Slack\BlockKit\Block\Markdown as SlackMarkdown;
 use Rocket\Slack\BlockKit\Block\Section as SlackSection;
-use Rocket\Slack\BlockKit\Element\Markdown as SlackMarkdown;
+use Rocket\Slack\BlockKit\Element\Mrkdwn as SlackMrkdwn;
 use Rocket\Slack\BlockKit\Message as SlackMessage;
 use Rocket\Version;
 
@@ -43,16 +44,10 @@ class SlackNotificationCommand implements CommandInterface
         $message = new SlackMessage('Rocket notification', $configure->read('slack.icon', ':sparkles:'));
 
         $chunker = new Chunker();
-        $chunks = $chunker($content, SlackSection::TEXT_MAX_LENGTH - 6);
+        $chunks = $chunker($content, SlackSection::MARKDOWN_MAX_LENGTH - 6);
 
         foreach ($chunks as $chunk) {
-            $message
-                ->addBlock(
-                    (new SlackSection())
-                        ->setText(
-                            new SlackMarkdown($chunk)
-                        )
-                );
+            $message->addBlock(new SlackMarkdown($chunk));
         }
 
         $message
@@ -62,18 +57,19 @@ class SlackNotificationCommand implements CommandInterface
             ->addBlock(
                 (new SlackContext())
                     ->addElement(
-                        new SlackMarkdown('Date: ' . date("Y/m/d H:i:s"))
+                        new SlackMrkdwn('Date: ' . date("Y/m/d H:i:s"))
                     )
                     ->addElement(
-                        new SlackMarkdown('Version: ' . Main::appName() . ' ' . Version::ROCKET_VERSION)
+                        new SlackMrkdwn('Version: ' . Main::appName() . ' ' . Version::ROCKET_VERSION)
                     )
                     ->addElement(
-                        new SlackMarkdown('Configuration: ' . $configure->getConfigPath())
+                        new SlackMrkdwn('Configuration: ' . $configure->getConfigPath())
                     )
             );
 
         $slack = new Slack(
-            $configure->read('slack.incomingWebhook'),
+            $configure->read('slack.chatPostMessageUrl'),
+            $configure->read('slack.appOauthToken'),
             $configure->read('slack.channel'),
             $configure->read('slack.username'),
             $this->http

--- a/src/Command/SlackNotificationTestCommand.php
+++ b/src/Command/SlackNotificationTestCommand.php
@@ -33,7 +33,8 @@ class SlackNotificationTestCommand implements CommandInterface
         $configure = new Configure($configPath);
 
         $slack = new Slack(
-            $configure->read('slack.incomingWebhook'),
+            $configure->read('slack.chatPostMessageUrl'),
+            $configure->read('slack.appOauthToken'),
             $configure->read('slack.channel'),
             $configure->read('slack.username'),
             $this->http

--- a/src/Configure.php
+++ b/src/Configure.php
@@ -7,7 +7,7 @@ use RuntimeException;
 
 class Configure
 {
-    const VERSION = '1.1';
+    const VERSION = '1.2';
 
     /** @var array  */
     private $config;

--- a/src/Http.php
+++ b/src/Http.php
@@ -20,13 +20,24 @@ class Http
         $this->ignoreVerify = $ignoreVerify;
     }
 
-    public function setupCurl($ch)
+    /**
+     * @param resource $ch
+     * @param array    $headers
+     */
+    public function setupCurl($ch, $headers = [])
     {
         curl_setopt($ch, CURLOPT_VERBOSE, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_AUTOREFERER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['User-Agent: rocket.phar/' . Version::ROCKET_VERSION]);
+        curl_setopt(
+            $ch,
+            CURLOPT_HTTPHEADER,
+            array_merge(
+                ['User-Agent: rocket.phar/' . Version::ROCKET_VERSION],
+                $headers
+            )
+        );
 
         if ($this->ignoreVerify) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
@@ -119,23 +130,24 @@ class Http
 
     /**
      * @param string $url
-     * @param string $contentType
+     * @param array  $headers
      * @param array  $data
      *
-     * @return bool|string
+     * @return HttpResponse
      */
-    public function post($url, $contentType, $data)
+    public function post($url, $headers, $data)
     {
         $ch = curl_init();
-        $this->setupCurl($ch);
+        $this->setupCurl($ch, $headers);
         curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: ' . $contentType]);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
 
         $result = curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
         curl_close($ch);
 
-        return $result;
+        return new HttpResponse($code, $result);
     }
 }

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rocket;
+
+class HttpResponse
+{
+    /** @var bool|string */
+    private $result;
+
+    /** @var int */
+    private $code;
+
+    /**
+     * @param int         $code
+     * @param bool|string $body
+     */
+    public function __construct($code, $body)
+    {
+        $this->code = $code;
+        $this->result = $body;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @return bool|string
+     */
+    public function getBody()
+    {
+        return $this->result;
+    }
+}

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -7,7 +7,8 @@ use Rocket\Slack\BlockKit\Block\Divider;
 use Rocket\Slack\BlockKit\Block\Header;
 use Rocket\Slack\BlockKit\Block\Image as BlockImage;
 use Rocket\Slack\BlockKit\Block\Section;
-use Rocket\Slack\BlockKit\Element\Markdown;
+use Rocket\Slack\BlockKit\Block\Markdown;
+use Rocket\Slack\BlockKit\Element\Mrkdwn;
 use Rocket\Slack\BlockKit\Element\PlainText;
 use Rocket\Slack\BlockKit\Message;
 use Rocket\Slack\SlackIncomingResult;
@@ -16,6 +17,9 @@ class Slack
 {
     /** @var string */
     private $url = null;
+
+    /** @var string */
+    private $appOauthToken = null;
 
     /** @var string */
     private $channel = null;
@@ -30,13 +34,15 @@ class Slack
      * Slack constructor.
      *
      * @param string      $url
+     * @param string      $appOauthToken
      * @param string|null $channel
      * @param string|null $username
      * @param Http|null   $http
      */
-    public function __construct($url, $channel = null, $username = null, $http = null)
+    public function __construct($url, $appOauthToken, $channel = null, $username = null, $http = null)
     {
         $this->url = $url;
+        $this->appOauthToken = $appOauthToken;
         $this->channel = $channel;
         $this->username = $username;
         $this->http = $http;
@@ -53,17 +59,19 @@ class Slack
             return new SlackIncomingResult(true);
         }
 
-        $result = $this->http->post(
-            $this->url,
-            'application/json',
-            $data
-        );
+        $headers = [
+            'Authorization: Bearer ' . $this->appOauthToken,
+            'Content-Type: application/json'
+        ];
+        $response = $this->http->post($this->url, $headers, $data);
+        $body = $response->getBody();
+        $result = json_decode($body, true);
 
-        if ($result === 'ok') {
+        if ($result['ok']) {
             return new SlackIncomingResult(true);
         }
 
-        return new SlackIncomingResult(false, $result);
+        return new SlackIncomingResult(false, $result['error']);
     }
 
     /**
@@ -91,10 +99,13 @@ class Slack
         $message = new Message('Test', $configure->read('slack.icon', ':sparkles:'));
         $message
             ->addBlock(
-                new Header(new PlainText('This is a test'))
+                new Markdown(
+                    '# This is a test message.' . PHP_EOL .
+                    '## Using chat.postMessage API :rocket:'
+                )
             )
             ->addBlock(
-                new BlockImage('https://picsum.photos/600/100', 'sample')
+                new BlockImage('https://picsum.photos/600/100?t=' . time(), 'sample')
             )
             ->addBlock(
                 (new Section())->setText(
@@ -104,41 +115,29 @@ class Slack
             ->addBlock(
                 (new Section())
                     ->addField(
-                        new Markdown('**Hostname:**' . PHP_EOL . gethostname())
+                        new Mrkdwn('*Hostname:*' . PHP_EOL . gethostname())
                     )
                     ->addField(
-                        new Markdown('**URL:**' . PHP_EOL . $configure->read('url'))
+                        new Mrkdwn('*URL:*' . PHP_EOL . $configure->read('url'))
                     )
             )
             ->addBlock(
                 new Divider()
             )
             ->addBlock(
-                (new Section())
-                    ->setText(
-                        new Markdown('**Git pull**')
-                    )
+                new Markdown('**Git pull**')
             )
             ->addBlock(
-                (new Section())
-                    ->setText(
-                        new Markdown('```HELLO WORLD```')
-                    )
+                new Markdown('```' . PHP_EOL . 'HELLO WORLD' . PHP_EOL .'```')
             )
             ->addBlock(
                 new Divider()
             )
             ->addBlock(
-                (new Section())
-                    ->setText(
-                        new Markdown('**Rsync**')
-                    )
+                new Markdown('**Rsync**')
             )
             ->addBlock(
-                (new Section())
-                    ->setText(
-                        new Markdown('```HELLO WORLD```')
-                    )
+                new Markdown('```' . PHP_EOL . 'HELLO WORLD' . PHP_EOL . '```')
             )
             ->addBlock(
                 new Divider()
@@ -146,15 +145,16 @@ class Slack
             ->addBlock(
                 (new Context())
                     ->addElement(
-                        new Markdown('Date: ' . date("Y/m/d H:i:s"))
+                        new Mrkdwn('Date: ' . date("Y/m/d H:i:s"))
                     )
                     ->addElement(
-                        new Markdown('Version: ' . Main::appName() . ' ' . Version::ROCKET_VERSION)
+                        new Mrkdwn('Version: ' . Main::appName() . ' ' . Version::ROCKET_VERSION)
                     )
                     ->addElement(
-                        new Markdown('Configuration: ' . $configure->getConfigPath())
+                        new Mrkdwn('Configuration: ' . $configure->getConfigPath())
                     )
-            );
+            )
+        ;
 
         return $this->send($message);
     }

--- a/src/Slack/BlockKit/Block/Markdown.php
+++ b/src/Slack/BlockKit/Block/Markdown.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rocket\Slack\BlockKit\Element;
+namespace Rocket\Slack\BlockKit\Block;
 
-class Markdown implements ElementInterface
+class Markdown implements BlockInterface
 {
     /** @var string */
     private $text;

--- a/src/Slack/BlockKit/Block/Section.php
+++ b/src/Slack/BlockKit/Block/Section.php
@@ -2,9 +2,8 @@
 
 namespace Rocket\Slack\BlockKit\Block;
 
-use Rocket\Slack\BlockKit\Element\Markdown;
-use Rocket\Slack\BlockKit\Element\Mrkdwn;
 use Rocket\Slack\BlockKit\Element\ElementInterface;
+use Rocket\Slack\BlockKit\Element\Mrkdwn;
 use Rocket\Slack\BlockKit\Element\PlainText;
 
 class Section implements BlockInterface
@@ -13,11 +12,12 @@ class Section implements BlockInterface
     const TEXT_MAX_LENGTH = 3000;
     const FIELD_TEXT_MAX_LENGTH = 2000;
     const FIELD_TEXT_MAX_ITEMS = 10;
+    const MARKDOWN_MAX_LENGTH = 12000;
 
-    /** @var PlainText|Mrkdwn|Markdown|null */
+    /** @var PlainText|Mrkdwn|null */
     private $text;
 
-    /** @var PlainText[]|Mrkdwn[]|Markdown[]|null */
+    /** @var PlainText[]|Mrkdwn[]|null */
     private $fields;
 
     /** @var ElementInterface|null */
@@ -35,7 +35,7 @@ class Section implements BlockInterface
     }
 
     /**
-     * @param Mrkdwn|Markdown|PlainText $text
+     * @param Mrkdwn|PlainText $text
      *
      * @return Section
      */
@@ -47,7 +47,7 @@ class Section implements BlockInterface
     }
 
     /**
-     * @param PlainText|Markdown|Mrkdwn $field
+     * @param PlainText|Mrkdwn $field
      *
      * @return Section
      */

--- a/src/Version.php
+++ b/src/Version.php
@@ -4,5 +4,5 @@ namespace Rocket;
 
 class Version
 {
-    const ROCKET_VERSION = '0.1.18';
+    const ROCKET_VERSION = '0.1.19';
 }

--- a/src/config/cakephp3.json
+++ b/src/config/cakephp3.json
@@ -1,9 +1,10 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "slack": {
     "channel": "channel-name",
     "username": "project-name",
-    "incomingWebhook": "https://hooks.slack.com/services/xxx",
+    "chatPostMessageUrl": "https://slack.com/api/chat.postMessage",
+    "appOauthToken": "SLACK_APP_OAUTH_TOKEN",
     "icon": ":tada:"
   },
   "user": "centos-user",

--- a/src/config/eccube4.json
+++ b/src/config/eccube4.json
@@ -1,9 +1,10 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "slack": {
     "channel": "channel-name",
     "username": "project-name",
-    "incomingWebhook": "https://hooks.slack.com/services/xxx",
+    "chatPostMessageUrl": "https://slack.com/api/chat.postMessage",
+    "appOauthToken": "SLACK_APP_OAUTH_TOKEN",
     "icon": ":tada:"
   },
   "user": "centos-user",

--- a/src/config/plain.json
+++ b/src/config/plain.json
@@ -1,9 +1,10 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "slack": {
     "channel": "channel-name",
     "username": "project-name",
-    "incomingWebhook": "https://hooks.slack.com/services/xxx",
+    "chatPostMessageUrl": "https://slack.com/api/chat.postMessage",
+    "appOauthToken": "SLACK_APP_OAUTH_TOKEN",
     "icon": ":tada:"
   },
   "user": "centos-user",

--- a/src/config/wordpress.json
+++ b/src/config/wordpress.json
@@ -1,9 +1,10 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "slack": {
     "channel": "channel-name",
     "username": "project-name",
-    "incomingWebhook": "https://hooks.slack.com/services/xxx",
+    "chatPostMessageUrl": "https://slack.com/api/chat.postMessage",
+    "appOauthToken": "SLACK_APP_OAUTH_TOKEN",
     "icon": ":tada:"
   },
   "user": "centos-user",

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -20,8 +20,8 @@ class HttpTest extends TestCase
     {
         $url = 'https://httpbin.org/post';
         $http = new Http();
-        $response = $http->post($url, 'application/json', ['HELLO' => 'WORLD']);
-        $map = json_decode($response, true);
+        $response = $http->post($url, ['Content-Type: application/json'], ['HELLO' => 'WORLD']);
+        $map = json_decode($response->getBody(), true);
 
         self::assertSame($url, $map['url']);
     }


### PR DESCRIPTION
## 📝 概要

Slack の Incoming Webhooks から `chat.postMessage` API へ移行し、新しい `Markdown` ブロックタイプのサポートを追加。合わせて `Http` クラスの `curl_close()` 順序バグおよびヘッダー上書きバグを修正し、`HttpResponse` クラスを新規追加した。

## ✨ 変更内容

- Slack の送信方式を Incoming Webhooks → `chat.postMessage` API に移行（`Authorization: Bearer` トークン認証に対応）
- `Markdown` クラスを `Element` から `Block` へ移動し、スタンドアロンブロックとして利用可能に
- `Http::post()` の `curl_getinfo()` を `curl_close()` の前に移動するバグを修正
- `CURLOPT_HTTPHEADER` が `User-Agent` を上書きしていた問題を修正
- `HttpResponse` クラスを新規追加し、HTTP ステータスコードとレスポンスボディを型安全に管理
- 設定ファイルのスキーマを `1.1` → `1.2` に更新（`incomingWebhook` → `chatPostMessageUrl` + `appOauthToken`）

## 🎯 影響範囲

| Cohort / File(s) | 変更概要 |
|-----------------|---------|
| Slack API 移行<br>`src/Slack.php`<br>`src/Command/DeployCommand.php`<br>`src/Command/SlackNotificationCommand.php`<br>`src/Command/SlackNotificationTestCommand.php` | Incoming Webhooks から `chat.postMessage` API へ移行。`appOauthToken` フィールドを追加し `Authorization: Bearer` ヘッダーで認証。レスポンス処理を plain text 比較から JSON パースに変更。 |
| HTTP クライアント改善<br>`src/Http.php`<br>`src/HttpResponse.php` | `curl_getinfo()` を `curl_close()` 前に移動するバグを修正。`setupCurl()` にヘッダー引数を追加し `post()` からの上書き問題を解消。`HttpResponse` クラスを新規追加してコード・ボディを分離管理。 |
| Markdown ブロック対応<br>`src/Slack/BlockKit/Block/Markdown.php`<br>`src/Slack/BlockKit/Block/Section.php` | `Markdown` クラスを `Element` 名前空間から `Block` 名前空間へ移動し `BlockInterface` を実装。`Section` に `MARKDOWN_MAX_LENGTH` 定数（12,000文字）を追加。 |
| 設定ファイルテンプレート更新<br>`src/config/cakephp3.json`<br>`src/config/eccube4.json`<br>`src/config/plain.json`<br>`src/config/wordpress.json`<br>`src/Configure.php` | スキーマバージョンを `1.1` → `1.2` に更新。`incomingWebhook` キーを `chatPostMessageUrl` と `appOauthToken` に置き換え。 |
| その他<br>`.gitignore`<br>`src/Version.php`<br>`tests/HttpTest.php` | `rocket.json` を `.gitignore` に追加。バージョンを `0.1.18` → `0.1.19` に更新。`HttpTest` を新しい `post()` シグネチャに合わせて修正。 |

**変更統計**:
- 変更ファイル数: 16件
- コミット数: 1件
- 追加: +142行
- 削除: -101行

## ✅ テスト

- `php ./bin/rocket.php --config ./rocket.json --notify-test` で `chat.postMessage` API 経由の送信および `Markdown` ブロックの表示を確認済み