### PR TITLE
Slack `mrkdwn` のボールド記法を修正しバージョンを 0.1.20 に更新・`ghpr.md` のシェル展開排除と変更ファイル数取得を改善

### DIFF
--- a/.claude/commands/ghpr.md
+++ b/.claude/commands/ghpr.md
@@ -44,10 +44,6 @@ description: Create a GitHub Pull Request using gh CLI
     - 重複を削除
     - ソート
 
-   または、以下のコマンドを使用（allowed-tools で許可されている場合）:
-   ```bash
-   git branch -r | grep -v HEAD | sed 's|origin/||' | grep -v "^$(git branch --show-current)$" | sort -u
-   ```
 
 2. **候補ブランチの優先順位付け**:
     - `develop`, `main`, `master` を優先的に表示
@@ -67,8 +63,10 @@ description: Create a GitHub Pull Request using gh CLI
 ### ステップ3: 既存 PR のチェック
 
 1. **同じブランチからの Open または Draft の PR が既に存在するか確認**:
+
+   `<現在のブランチ名>` にはステップ1で取得したブランチ名をリテラル文字列として代入する（shell substitution 不可）。
    ```bash
-   gh pr list --head $(git branch --show-current) --base <選択されたベースブランチ> --state all --json number,title,state,url
+   gh pr list --head <現在のブランチ名> --base <選択されたベースブランチ> --state all --json number,title,state,url
    ```
 
    **重要**: `--state all` で全てのPRを取得し、Claude が `state` フィールドをチェックして **`OPEN` または `DRAFT` のPRのみ**を抽出します。`MERGED` や `CLOSED` のPRは除外してください。
@@ -159,9 +157,11 @@ description: Create a GitHub Pull Request using gh CLI
         - No → 処理を終了
 
     - 結果が `OPEN` または `DRAFT` の場合:
+
+      `<現在のブランチ名>` にはステップ1で取得したブランチ名をリテラル文字列として代入する（shell substitution 不可）。
       ```bash
       # 最新のコミットをリモートに push
-      git push origin $(git branch --show-current)
+      git push origin <現在のブランチ名>
       
       # PR の URL を表示
       gh pr view <PR番号> --json url -q .url
@@ -277,11 +277,10 @@ git rev-list --count origin/<base-branch>..HEAD
 ---
 
 **手順4**: 変更ファイル数を確認
-```bash
-git diff origin/<base-branch>..HEAD --name-only | wc -l
-```
 
-**例**: 出力が `3` なら、3ファイルが変更されている。
+手順5-1で取得する `git diff origin/<base-branch>..HEAD --numstat` の出力行数を数えて変更ファイル数とする。
+
+**例**: 出力が3行なら、3ファイルが変更されている。
 
 ---
 

--- a/src/Command/DeployCommand.php
+++ b/src/Command/DeployCommand.php
@@ -272,10 +272,10 @@ class DeployCommand implements CommandInterface
             ->addBlock(
                 (new SlackSection())
                     ->addField(
-                        new SlackMrkdwn('**Hostname:**' . PHP_EOL . gethostname())
+                        new SlackMrkdwn('*Hostname:*' . PHP_EOL . gethostname())
                     )
                     ->addField(
-                        new SlackMrkdwn('**URL:**' . PHP_EOL . $configure->read('url'))
+                        new SlackMrkdwn('*URL:*' . PHP_EOL . $configure->read('url'))
                     )
             );
 

--- a/src/Version.php
+++ b/src/Version.php
@@ -4,5 +4,5 @@ namespace Rocket;
 
 class Version
 {
-    const ROCKET_VERSION = '0.1.19';
+    const ROCKET_VERSION = '0.1.20';
 }


### PR DESCRIPTION
## 📝 概要
Slack の `mrkdwn` 記法におけるボールド記法の誤り (`**text**`) を正しい Slack 形式 (`*text*`) に修正します。また、`ghpr.md` コマンド定義のシェル展開による誤動作を排除し、変更ファイル数の取得方法を改善します。

## ✨ 変更内容
- Slack `DeployCommand` 内の `mrkdwn` ボールド記法を `**text**` から `*text*` に修正
- `Version::ROCKET_VERSION` を `0.1.19` から `0.1.20` にバージョンアップ
- `ghpr.md` の `$(git branch --show-current)` シェル展開を排除しリテラル文字列でブランチ名を指定するよう変更
- `git diff --name-only | wc -l` を `--numstat` の行数カウントに変更

## 🎯 影響範囲

| Cohort / File(s) | 変更概要 |
|-----------------|----------|
| Slack 記法修正<br>`src/Command/DeployCommand.php` | `mrkdwn` ボールドの記法を Slack API 仕様に準拠した正しい形式 (`*text*`) に修正。`Hostname:` と `URL:` ラベルのボールド表示が正しく機能するようになります。 |
| バージョン更新<br>`src/Version.php` | `ROCKET_VERSION` を `0.1.19` から `0.1.20` にインクリメント。上記の修正を反映したパッチバージョンアップ。 |
| `ghpr.md` コマンド定義の改善<br>`.claude/commands/ghpr.md` | `$(git branch --show-current)` のシェル展開を排除しブランチ名をリテラル値で指定するよう変更。`git diff | wc -l` の代わりに `--numstat` の出力行数を利用する方法に改善し、不要な bash コマンドを削除。 |

**変更統計**:
- 変更ファイル数: 3件
- コミット数: 2件
- 追加: +12行
- 削除: -13行

## ✅ テスト
- Slack の `mrkdwn` ボールド表示を実際のデプロイチャンネルで確認