### PR TITLE
 の  上限値を誤った 12000 から正しい 3000 に修正

### DIFF
--- a/src/Slack/BlockKit/Block/Section.php
+++ b/src/Slack/BlockKit/Block/Section.php
@@ -12,7 +12,7 @@ class Section implements BlockInterface
     const TEXT_MAX_LENGTH = 3000;
     const FIELD_TEXT_MAX_LENGTH = 2000;
     const FIELD_TEXT_MAX_ITEMS = 10;
-    const MARKDOWN_MAX_LENGTH = 12000;
+    const MARKDOWN_MAX_LENGTH = 3000;
 
     /** @var PlainText|Mrkdwn|null */
     private $text;

--- a/src/Version.php
+++ b/src/Version.php
@@ -4,5 +4,5 @@ namespace Rocket;
 
 class Version
 {
-    const ROCKET_VERSION = '0.1.20';
+    const ROCKET_VERSION = '0.1.21';
 }


### PR DESCRIPTION
## 📝 概要
`Section` ブロックの `MARKDOWN_MAX_LENGTH` 定数が誤って `12000` に設定されていたため、正しい値である `3000` に修正しました。この修正に伴い、バージョンを `0.1.21` に更新しました。

## ✨ 変更内容
- `Section::MARKDOWN_MAX_LENGTH` を `12000` から `3000` に修正
- バージョンを `0.1.20` から `0.1.21` に更新

## 🎯 影響範囲

| Cohort / File(s) | 変更概要 |
|-----------------|----------|
| 上限値定数の修正<br>`src/Slack/BlockKit/Block/Section.php` | `MARKDOWN_MAX_LENGTH` 定数の値を誤った `12000` から正しい `3000` に修正。`TEXT_MAX_LENGTH` と統一した上限値となります。 |
| バージョン更新<br>`src/Version.php` | バージョン定数を `0.1.20` から `0.1.21` に更新。 |

**変更統計**:
- 変更ファイル数: 2件
- コミット数: 1件
- 追加: +2行
- 削除: -2行

## ✅ テスト
定数値の修正のみのため、既存のテストで確認済み